### PR TITLE
Fix some typos, copy-paste, and missing `usings` bugs

### DIFF
--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -287,11 +287,11 @@ namespace Knossos.NET.Models
                 {
                     if (int.Parse(data["Default"]["SpeechMulti"]) == 1)
                     {
-                        ttsIngame = true;
+                        ttsMulti = true;
                     }
                     else
                     {
-                        ttsIngame = false;
+                        ttsMulti = false;
                     }
                 }
 

--- a/Knossos.NET/Models/Nebula.cs
+++ b/Knossos.NET/Models/Nebula.cs
@@ -12,6 +12,7 @@ using System.Text.Json.Serialization;
 using Avalonia.Threading;
 using System.Collections.Generic;
 using Knossos.NET.Classes;
+using System.Threading;
 
 namespace Knossos.NET.Models
 {

--- a/Knossos.NET/ViewModels/Windows/Fs2InstallerViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/Fs2InstallerViewModel.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace Knossos.NET.ViewModels
 {

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -19,7 +19,7 @@
 					<Button Grid.Row="0" Command="{Binding ReloadFlagData}" Foreground="White" Background="Black" Grid.Column="1" Margin="5,0,0,0">Reload Data</Button>
 					<Button Grid.Row="0" Command="{Binding ResetCommand}" Grid.Column="0" FontWeight="Bold" Foreground="White" Background="Red">RESET</Button>
 				</Grid>
-				<TextBlock TextWrapping="Wrap" FontSize="13" VerticalAlignment="Center" HorizontalAlignment="Center">It is not recomended that you leave this tab open while playing, as Knossos constanly scan for .ini changes here.</TextBlock>
+				<TextBlock TextWrapping="Wrap" FontSize="13" VerticalAlignment="Center" HorizontalAlignment="Center">It is not recommended that you leave this tab open while playing, as Knossos constantly scans here for changes to the .ini file.</TextBlock>
 			</StackPanel>
 		</Border>
 		<ScrollViewer Grid.Row="1">


### PR DESCRIPTION
Fixed spelling and also slightly reworded to help highlight that the .ini is a file (in case there are very new folks who do not know what that means). Happy to change however. 

EDIT: Also fixes copy-paste bug with TTS settings and missing usings.