### PR TITLE
Fix some typos

### DIFF
--- a/Knossos.NET/Classes/SemanticVersion.cs
+++ b/Knossos.NET/Classes/SemanticVersion.cs
@@ -4,7 +4,7 @@ namespace Knossos.NET.Classes
 {
     /*
         Helper class to handle semantic versions used by FSO and Knossos.
-        Just the basics needed to do comparisons whiout having to include 
+        Just the basics needed to do comparisons without having to include 
         a 3rd party library for this.
     */
     public class SemanticVersion

--- a/Knossos.NET/Models/ModSettings.cs
+++ b/Knossos.NET/Models/ModSettings.cs
@@ -100,7 +100,7 @@ namespace Knossos.NET.Models
                 }
                 else
                 {
-                    Log.Add(Log.LogSeverity.Error, "ModSettings.Save()", "A mod tried to save mod_settings.json to a null filePath, this happens if you try to Save() whiout calling Load() first.");
+                    Log.Add(Log.LogSeverity.Error, "ModSettings.Save()", "A mod tried to save mod_settings.json to a null filePath, this happens if you try to Save() without calling Load() first.");
                 }
             }
             catch (Exception ex)

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -63,7 +63,7 @@
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5" >
 							<CheckBox IsVisible="{Binding IsAVX}" Grid.Column="0" ToolTip.Tip="If available, Knossos will force to run SSE2 FSO builds instead of AVX ones." IsChecked="{Binding ForceSSE2}" Width="200">Force SSE2 Builds</CheckBox>
 							<CheckBox IsChecked="{Binding CheckUpdates}" Margin="5,0,0,0" Grid.Column="1" ToolTip.Tip="Knossos.NET will connect to the GitHub repo to check for avalible updates at the start.">Check for updates at startup</CheckBox>
-							<CheckBox IsVisible="{Binding CheckUpdates}" Margin="5,0,0,0" Grid.Column="2" IsChecked="{Binding AutoUpdate}" ToolTip.Tip="The update will be automatically downloaded and installed. KnossosNET will be restarted whiout any user input.">Auto Update</CheckBox>
+							<CheckBox IsVisible="{Binding CheckUpdates}" Margin="5,0,0,0" Grid.Column="2" IsChecked="{Binding AutoUpdate}" ToolTip.Tip="The update will be automatically downloaded and installed. KnossosNET will be restarted without any user input.">Auto Update</CheckBox>
 						</Grid>
 						<!-- SubTasks -->
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">

--- a/Knossos.NET/Views/Windows/QuickSetupView.axaml
+++ b/Knossos.NET/Views/Windows/QuickSetupView.axaml
@@ -55,7 +55,7 @@
 		<!--Page4-->
 		<StackPanel IsVisible="{Binding Page4}" Grid.Row="0" >
 			<TextBlock TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Center">Freespace 2 Retail</TextBlock>
-			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Center">In order to have access to Freespace 1 and 2 content and visual improvements you need to install Freespace 2 Retail in Knossos. Whiout this any content that needs the full Freespace 2 retail files will not be displayed on the Nebula tab.</TextBlock>
+			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Center">In order to have access to Freespace 1 and 2 content and visual improvements you need to install Freespace 2 Retail in Knossos. without this any content that needs the full Freespace 2 retail files will not be displayed on the Nebula tab.</TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Center">To install Freespace 2 go to the "Settings" tab and open the "FS2 Retail Installer" the button is on the "Knossos Settings" section. Then follow the instructions there. If you already have FS2 installed this button is not avalible.</TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Center">This step is optional and you can continue at any time</TextBlock>
 		</StackPanel>


### PR DESCRIPTION
Mainly fixing copy-paste typo of `without`