### PR TITLE
Add Button to automatically clean the Knossos library

### DIFF
--- a/Knossos.NET/Knossos.NET.csproj
+++ b/Knossos.NET/Knossos.NET.csproj
@@ -18,6 +18,14 @@
     <None Remove="ViewModels\ModCardViewModel.cs~RF423e49e6.TMP" />
     <None Remove="ViewModels\Windows\ModInstallViewModel.cs~RF3e55a24c.TMP" />
     <None Remove="Views\Windows\ModDetailsView.axaml~RF2bc1dec5.TMP" />
+    <Compile Update="Views\Windows\CleanupKnossosLibraryView.axaml.cs">
+      <DependentUpon>CleanupKnossosLibraryView.axaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Update="Views\Templates\CheckableModListView.axaml.cs">
+      <DependentUpon>CheckableModListView.axaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <AvaloniaResource Include="Assets\*" />

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -982,5 +982,16 @@ namespace Knossos.NET.ViewModels
         {
             Knossos.OpenQuickSetup();
         }
+        
+        internal async void CleanupLibraryCommand()
+        {
+            if (MainWindow.instance != null)
+            {
+                var dialog = new CleanupKnossosLibraryView();
+                dialog.DataContext = new CleanupKnossosLibraryViewModel();
+
+                await dialog.ShowDialog<CleanupKnossosLibraryView?>(MainWindow.instance);
+            }
+        }
     }
 }

--- a/Knossos.NET/ViewModels/Templates/CheckableModListViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/CheckableModListViewModel.cs
@@ -34,7 +34,7 @@ namespace Knossos.NET.ViewModels
         {
             modJson.ClearUnusedData();
             mod = modJson;
-            ModName = modJson.title;
+            ModName = modJson.ToString();
             ModChecked = true;
             ModCheckEnabled = true;
         }

--- a/Knossos.NET/ViewModels/Templates/CheckableModListViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/CheckableModListViewModel.cs
@@ -1,28 +1,12 @@
-﻿using Avalonia;
-using Avalonia.Platform;
-using Avalonia.Media.Imaging;
-using System;
-using Knossos.NET.Models;
-using Avalonia.Media;
+﻿using Knossos.NET.Models;
 using CommunityToolkit.Mvvm.ComponentModel;
-using System.Collections.Generic;
-using Knossos.NET.Classes;
-using Knossos.NET.Views;
-using System.IO;
-using System.Net.Http;
-using System.Threading.Tasks;
-using Avalonia.Controls;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Linq;
-using Avalonia.Threading;
 
 namespace Knossos.NET.ViewModels
 {
     public partial class CheckableModListViewModel : ViewModelBase
     {
         /* General Mod variables */
-        private Mod? mod { get; set; }
+        public Mod? mod { get; set; }
         private bool modCheckedBackup;
         
         public delegate void OnModCheckChanged(Mod mod, bool modChecked);

--- a/Knossos.NET/ViewModels/Templates/CheckableModListViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/CheckableModListViewModel.cs
@@ -1,0 +1,84 @@
+﻿using Avalonia;
+using Avalonia.Platform;
+using Avalonia.Media.Imaging;
+using System;
+using Knossos.NET.Models;
+using Avalonia.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.Generic;
+using Knossos.NET.Classes;
+using Knossos.NET.Views;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Linq;
+using Avalonia.Threading;
+
+namespace Knossos.NET.ViewModels
+{
+    public partial class CheckableModListViewModel : ViewModelBase
+    {
+        /* General Mod variables */
+        private Mod? mod { get; set; }
+        private bool modCheckedBackup;
+        
+        public delegate void OnModCheckChanged(Mod mod, bool modChecked);
+
+        public OnModCheckChanged? onModCheckChangedHandler;
+
+        /* UI Bindings */
+        [ObservableProperty]
+        private string? modName;
+        [ObservableProperty]
+        private bool modChecked;
+        [ObservableProperty]
+        private bool modCheckEnabled;
+
+        /* Should only be used by the editor preview */
+        public CheckableModListViewModel()
+        {
+            mod = null;
+            ModName = "";
+            ModChecked = true;
+            ModCheckEnabled = true;
+        }
+
+        public CheckableModListViewModel(Mod modJson)
+        {
+            modJson.ClearUnusedData();
+            mod = modJson;
+            ModName = modJson.title;
+            ModChecked = true;
+            ModCheckEnabled = true;
+        }
+
+        partial void OnModCheckedChanging(bool value)
+        {
+            if (mod != null)
+            {
+                onModCheckChangedHandler?.Invoke(mod, value);
+            }
+        }
+
+        public void SetModCheckedEnabled(bool enabled)
+        {
+            if (enabled == ModCheckEnabled)
+                return;
+            
+            if (!enabled)
+            {
+                modCheckedBackup = ModChecked;
+                ModChecked = false;
+            }
+            else
+            {
+                ModChecked = modCheckedBackup;
+            }
+
+            ModCheckEnabled = enabled;
+        }
+    }
+}

--- a/Knossos.NET/ViewModels/Windows/CleanupKnossosLibraryViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/CleanupKnossosLibraryViewModel.cs
@@ -1,10 +1,7 @@
 using Avalonia.Threading;
-using Knossos.NET.Views;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Knossos.NET.Classes;
@@ -16,6 +13,8 @@ namespace Knossos.NET.ViewModels
     {
         private ObservableCollection<CheckableModListViewModel> DeletableMods { get; set; } = new ObservableCollection<CheckableModListViewModel>();
         
+        public event EventHandler? OnRequestClose;
+
         public async void LoadRemovableMods()
         { 
             await Task.Run(async () => 
@@ -109,6 +108,23 @@ namespace Knossos.NET.ViewModels
                     Log.Add(Log.LogSeverity.Error, "CleanupKnossosLibraryViewModel.LoadRemovableMods", ex);
                 }
             });
+        }
+
+        internal void Cleanup()
+        {
+            foreach (var modView in DeletableMods)
+            {
+                if (!modView.ModChecked)
+                    continue;
+
+                var mod = modView.mod;
+                if (mod == null)
+                    continue;
+
+                Knossos.RemoveMod(mod);
+            }
+            MainWindowViewModel.Instance?.RunModStatusChecks();
+            OnRequestClose?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/Knossos.NET/ViewModels/Windows/CleanupKnossosLibraryViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/CleanupKnossosLibraryViewModel.cs
@@ -66,17 +66,14 @@ namespace Knossos.NET.ViewModels
                         var dependencyList = toRemove.GetModDependencyList(false, true) ?? Enumerable.Empty<ModDependency>().Union(toRemove.GetModDependencyList(true, true) ?? Enumerable.Empty<ModDependency>()).Distinct();
                         var dependencyModList = new Collection<Mod>();
                         
-                        Console.Write("Mod: " + toRemove.id + " " + toRemove.version + " Dep:");
                         foreach (var dep in dependencyList)
                         {
                             var depMod = dep.SelectMod();
                             if (depMod != null)
                             {
                                 dependencyModList.Add(depMod);
-                                Console.Write(depMod.id + " " + depMod.version + ";");
                             }
                         }
-                        Console.WriteLine();
                         
                         modDependencies.Add(toRemove, dependencyModList);
                     }
@@ -90,7 +87,9 @@ namespace Knossos.NET.ViewModels
                             
                             foreach (var dep in modDependencies[mod.Key])
                             {
-                                dependencyViews.Add(modViewModels[dep]);
+                                //If this mod depends on any other mod we could be removing, make sure that we don't remove the dependency if we don't remove this mod
+                                if (modViewModels.ContainsKey(dep))
+                                    dependencyViews.Add(modViewModels[dep]);
                             }
                             
                             mod.Value.onModCheckChangedHandler = (modChanged, modChecked) =>
@@ -112,6 +111,7 @@ namespace Knossos.NET.ViewModels
 
         internal void Cleanup()
         {
+            /*TODO: Make async (depends on async-capable Knossos.RemoveMod())*/
             foreach (var modView in DeletableMods)
             {
                 if (!modView.ModChecked)

--- a/Knossos.NET/ViewModels/Windows/CleanupKnossosLibraryViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/CleanupKnossosLibraryViewModel.cs
@@ -1,0 +1,114 @@
+using Avalonia.Threading;
+using Knossos.NET.Views;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Knossos.NET.Classes;
+using Knossos.NET.Models;
+
+namespace Knossos.NET.ViewModels
+{
+    public partial class CleanupKnossosLibraryViewModel : ViewModelBase
+    {
+        private ObservableCollection<CheckableModListViewModel> DeletableMods { get; set; } = new ObservableCollection<CheckableModListViewModel>();
+        
+        public async void LoadRemovableMods()
+        { 
+            await Task.Run(async () => 
+            {
+                try
+                {
+                    var modsToKeep = new Collection<Mod>();
+
+                    var newestMod = new Dictionary<string, string>();
+                    foreach (var mod in Knossos.GetInstalledModList(null))
+                    {
+                        //Always keep mods in dev mode
+                        if (mod.devMode)
+                        {
+                            modsToKeep.Add(mod);
+                            continue;
+                        }
+
+                        if (!newestMod.ContainsKey(mod.id) || SemanticVersion.Compare(newestMod[mod.id], mod.version) < 0)
+                        {
+                            newestMod[mod.id] = mod.version;
+                        }
+                    }
+
+                    foreach (var newestModVersion in newestMod)
+                    {
+                        //Keep newest version of mod
+                        Mod mod = Knossos.GetInstalledMod(newestModVersion.Key, newestModVersion.Value)!;
+                        modsToKeep.Add(mod);
+                        
+                        //And all of its dependencies, both those it has set from nebula, and those set as a manual override
+                        var dependencyList = mod.GetModDependencyList() ?? Enumerable.Empty<ModDependency>().Union(mod.GetModDependencyList(true) ?? Enumerable.Empty<ModDependency>()).Distinct();
+                        foreach (var dependency in dependencyList)
+                        {
+                            var resolved = dependency.SelectMod();
+                            if (resolved != null)
+                                modsToKeep.Add(resolved);
+                        }
+                    }
+
+                    var modViewModels = new Dictionary<Mod, CheckableModListViewModel>();
+                    var modDependencies = new Dictionary<Mod, Collection<Mod>>();
+                    foreach (var toRemove in Knossos.GetInstalledModList(null).Except(modsToKeep.Distinct()))
+                    {
+                        //Make a checkbox for any mod not to keep
+                        modViewModels.Add(toRemove, new CheckableModListViewModel(toRemove));
+                       
+                        //Also, figure out its dependencies in case the user selects to keep the mod anyways
+                        var dependencyList = toRemove.GetModDependencyList(false, true) ?? Enumerable.Empty<ModDependency>().Union(toRemove.GetModDependencyList(true, true) ?? Enumerable.Empty<ModDependency>()).Distinct();
+                        var dependencyModList = new Collection<Mod>();
+                        
+                        Console.Write("Mod: " + toRemove.id + " " + toRemove.version + " Dep:");
+                        foreach (var dep in dependencyList)
+                        {
+                            var depMod = dep.SelectMod();
+                            if (depMod != null)
+                            {
+                                dependencyModList.Add(depMod);
+                                Console.Write(depMod.id + " " + depMod.version + ";");
+                            }
+                        }
+                        Console.WriteLine();
+                        
+                        modDependencies.Add(toRemove, dependencyModList);
+                    }
+                    
+                    //Add the Checkboxes and link their dependencies
+                    await Dispatcher.UIThread.InvokeAsync(() =>
+                    {
+                        foreach(var mod in modViewModels.OrderBy(mod => mod.Key.tile))
+                        {
+                            var dependencyViews = new Collection<CheckableModListViewModel>();
+                            
+                            foreach (var dep in modDependencies[mod.Key])
+                            {
+                                dependencyViews.Add(modViewModels[dep]);
+                            }
+                            
+                            mod.Value.onModCheckChangedHandler = (modChanged, modChecked) =>
+                            {
+                                foreach (var dependency in dependencyViews)
+                                    dependency.SetModCheckedEnabled(modChecked);
+                            };
+                            
+                            DeletableMods.Add(mod.Value);
+                        }
+                    }, DispatcherPriority.Default);
+                }
+                catch (Exception ex)
+                {
+                    Log.Add(Log.LogSeverity.Error, "CleanupKnossosLibraryViewModel.LoadRemovableMods", ex);
+                }
+            });
+        }
+    }
+}

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -45,6 +45,7 @@
 								<CheckBox Margin="40,0,0,0" IsEnabled="False" IsChecked="{Binding Fs2RootPack}">FS2 Root Pack</CheckBox>
 								<Button Command="{Binding InstallFS2Command}" IsVisible="{Binding !Fs2RootPack}" Background="Black" Margin="10,0,0,0">FS2 Retail Installer</Button>
 								<Button Command="{Binding QuickSetupCommand}" Background="Black" Margin="5,0,0,0">Quick Setup Guide</Button>
+								<Button Command="{Binding CleanupLibraryCommand}" Background="Black" Margin="5,0,0,0">Remove Unused Dependencies</Button>
 							</WrapPanel>
 						</Grid>
 						<!-- Sys Info -->

--- a/Knossos.NET/Views/Templates/CheckableModListView.axaml
+++ b/Knossos.NET/Views/Templates/CheckableModListView.axaml
@@ -1,0 +1,15 @@
+<UserControl  IsVisible="{Binding Visible}"  xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Knossos.NET.Views.CheckableModListView"
+			 xmlns:vm="clr-namespace:Knossos.NET.ViewModels;assembly=Knossos.NET">
+	
+	<Design.DataContext>
+		<vm:CheckableModListViewModel/>
+	</Design.DataContext>
+	
+	<CheckBox IsChecked="{Binding ModChecked}" IsEnabled="{Binding ModCheckEnabled}"><TextBlock Text="{Binding ModName}"/></CheckBox>
+	
+</UserControl>

--- a/Knossos.NET/Views/Templates/CheckableModListView.axaml.cs
+++ b/Knossos.NET/Views/Templates/CheckableModListView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace Knossos.NET.Views
+{
+    public partial class CheckableModListView : UserControl
+    {
+        public CheckableModListView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Knossos.NET/Views/Windows/CleanupKnossosLibraryView.axaml
+++ b/Knossos.NET/Views/Windows/CleanupKnossosLibraryView.axaml
@@ -24,5 +24,6 @@
 				</DataTemplate>
 			</ListBox.ItemTemplate>
 		</ListBox>
+		<Button Command="{Binding Cleanup}" Margin="10">Delete Selected Mods</Button>
 	</StackPanel>
 </Window>

--- a/Knossos.NET/Views/Windows/CleanupKnossosLibraryView.axaml
+++ b/Knossos.NET/Views/Windows/CleanupKnossosLibraryView.axaml
@@ -1,0 +1,28 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        x:Class="Knossos.NET.Views.CleanupKnossosLibraryView"
+        xmlns:v="clr-namespace:Knossos.NET.Views;assembly=Knossos.NET"
+		xmlns:vm="clr-namespace:Knossos.NET.ViewModels;assembly=Knossos.NET"
+		Icon="/Assets/knossos-icon.ico"
+		WindowStartupLocation="CenterScreen"
+        Title="Knossos Library Cleanup" 
+		SizeToContent="WidthAndHeight" 
+		CanResize="False">
+	
+	<Design.DataContext>
+		<vm:CleanupKnossosLibraryViewModel/>
+	</Design.DataContext>
+	<StackPanel MaxWidth="500" Background="#18191A">
+		<TextBlock Margin="10" TextWrapping="Wrap">The following are old versions of mods that are not needed as any dependency and can be safely deleted. Uncheck all mod versions you want to keep.</TextBlock>
+		<ListBox ItemsSource="{Binding DeletableMods}">
+			<ListBox.ItemTemplate>
+				<DataTemplate>
+					<v:CheckableModListView Content="{Binding}"/>
+				</DataTemplate>
+			</ListBox.ItemTemplate>
+		</ListBox>
+	</StackPanel>
+</Window>

--- a/Knossos.NET/Views/Windows/CleanupKnossosLibraryView.axaml.cs
+++ b/Knossos.NET/Views/Windows/CleanupKnossosLibraryView.axaml.cs
@@ -14,6 +14,7 @@ namespace Knossos.NET.Views
         protected override void OnOpened(EventArgs e)
         {
             base.OnOpened(e);
+            ((CleanupKnossosLibraryViewModel)DataContext!).OnRequestClose += (s, ev) => Close();
             ((CleanupKnossosLibraryViewModel)DataContext!).LoadRemovableMods();
         }
     }

--- a/Knossos.NET/Views/Windows/CleanupKnossosLibraryView.axaml.cs
+++ b/Knossos.NET/Views/Windows/CleanupKnossosLibraryView.axaml.cs
@@ -1,0 +1,20 @@
+using System;
+using Avalonia.Controls;
+using Knossos.NET.ViewModels;
+
+namespace Knossos.NET.Views
+{
+    public partial class CleanupKnossosLibraryView : Window
+    {
+        public CleanupKnossosLibraryView()
+        {
+            InitializeComponent();
+        }
+
+        protected override void OnOpened(EventArgs e)
+        {
+            base.OnOpened(e);
+            ((CleanupKnossosLibraryViewModel)DataContext!).LoadRemovableMods();
+        }
+    }
+}


### PR DESCRIPTION
This will scan the installed mods for all older versions of installed mods that are not used as dependencies, and present them to the user for deletion.
If the user deselects a mod that should be deleted, it's dependencies will also automatically be prevented from deletion.
Takes into account _both_ custom user dependencies and nebula dependencies.