### PR TITLE
Add MSAA Option to Graphics Settings

### DIFF
--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -74,9 +74,11 @@ namespace Knossos.NET.Models
         [JsonIgnore]
         public int textureFilter { get; set; } = 1;
         [JsonIgnore]
-        public int shadowQuality { get; set; } = 2;
+        public int shadowQuality { get; set; } = 0;
         [JsonIgnore]
-        public int aaPreset { get; set; } = 6;
+        public int aaPreset { get; set; } = 4;
+        [JsonIgnore]
+        public int msaaPreset { get; set; } = 0;
         [JsonIgnore]
         public bool enableSoftParticles { get; set; } = true;
         [JsonIgnore]
@@ -397,6 +399,11 @@ namespace Knossos.NET.Models
                     aaPreset = int.Parse(data["Graphics"]["AAMode"]);
                 }
 
+                if (!string.IsNullOrEmpty(data["Graphics"]["MSAAMode"]))
+                {
+                    msaaPreset = int.Parse(data["Graphics"]["MSAAMode"]);
+                }
+
                 if (!string.IsNullOrEmpty(data["Graphics"]["SoftParticles"]))
                 {
                     enableSoftParticles = bool.Parse(data["Graphics"]["SoftParticles"]);
@@ -614,6 +621,7 @@ namespace Knossos.NET.Models
                 }
                 data["Graphics"]["Shadows"] = shadowQuality.ToString();
                 data["Graphics"]["AAMode"] = aaPreset.ToString();
+                data["Graphics"]["MSAAMode"] = msaaPreset.ToString();
                 data["Graphics"]["WindowMode"] = windowMode.ToString();
                 data["Graphics"]["Display"] = displayIndex.ToString();
                 data["Graphics"]["TextureFilter"] = textureFilter.ToString();
@@ -747,7 +755,15 @@ namespace Knossos.NET.Models
                     }
                 }
             }
-            if(enableSoftParticles)
+            if (msaaPreset > 0)
+            {
+                switch (msaaPreset)
+                {
+                    case 1: cmd += "-msaa 4"; break;
+                    case 2: cmd += "-msaa 8"; break;
+                }
+            }
+                if (enableSoftParticles)
             {
                 cmd += "-soft_particles";
             }

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -85,9 +85,11 @@ namespace Knossos.NET.ViewModels
         private int textureSelectedIndex = 0;
         private ObservableCollection<ComboBoxItem> ResolutionItems { get; set; } = new ObservableCollection<ComboBoxItem>();
         [ObservableProperty]
-        private int shadowQualitySelectedIndex = 2;
+        private int shadowQualitySelectedIndex = 0;
         [ObservableProperty]
-        private int aaSelectedIndex = 6;
+        private int aaSelectedIndex = 5;
+        [ObservableProperty]
+        private int msaaSelectedIndex = 0;
         [ObservableProperty]
         private bool enableSoftParticles = true;
         [ObservableProperty]
@@ -305,6 +307,8 @@ namespace Knossos.NET.ViewModels
             ShadowQualitySelectedIndex = Knossos.globalSettings.shadowQuality;
             //AA
             AaSelectedIndex = Knossos.globalSettings.aaPreset;
+            //MSAA
+            MsaaSelectedIndex = Knossos.globalSettings.msaaPreset;
             //SoftParticles
             EnableSoftParticles = Knossos.globalSettings.enableSoftParticles;
             //WindowMode
@@ -804,6 +808,8 @@ namespace Knossos.NET.ViewModels
             Knossos.globalSettings.shadowQuality = ShadowQualitySelectedIndex;
             //AA
             Knossos.globalSettings.aaPreset = AaSelectedIndex;
+            //MSAA
+            Knossos.globalSettings.msaaPreset = MsaaSelectedIndex;
             //SoftParticles
             Knossos.globalSettings.enableSoftParticles = EnableSoftParticles;
             //WindowMode

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -168,7 +168,7 @@
 						</Grid>
 						<!-- AA Filter -->
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<Label Grid.Column="0" Width="200" VerticalAlignment="Center">Anti-Aliasing</Label>
+							<Label Grid.Column="0" Width="200" VerticalAlignment="Center">Post-processing Anti-Aliasing</Label>
 							<ComboBox Tag="-aa_preset" SelectedIndex="{Binding AaSelectedIndex}" Grid.Column="1" IsEnabled="{Binding EnableAA}" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
 								<ComboBoxItem Tag="1">FXAA Low</ComboBoxItem>
@@ -180,6 +180,15 @@
 								<ComboBoxItem Tag="7">SMAA Ultra</ComboBoxItem>
 							</ComboBox>
 						</Grid>
+            <!-- SMAA Filter -->
+            <Grid ColumnDefinitions="Auto,Auto" Margin="5">
+              <Label Grid.Column="0" Width="200" VerticalAlignment="Center">Extra Multisample Anti-Aliasing</Label>
+              <ComboBox  ToolTip.Tip="High performance impact, especially at Ultra" Tag="-msaa" SelectedIndex="{Binding MsaaSelectedIndex}" Grid.Column="1" IsEnabled="{Binding EnableMSAA}" Width="150" Margin="10,0,0,0">
+                <ComboBoxItem Tag="0">Disabled</ComboBoxItem>
+                <ComboBoxItem Tag="4">High</ComboBoxItem>
+                <ComboBoxItem Tag="8">Ultra</ComboBoxItem>
+              </ComboBox>
+            </Grid>
 						<!-- Enable soft particles -->
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
 							<CheckBox Tag="-soft_particles" Grid.Column="0" IsChecked="{Binding EnableSoftParticles}" Width="200">Enable soft particles</CheckBox>


### PR DESCRIPTION
The recently added MSAA flag option is an extra pass done after the basal AA pass. The MSAA pass greatly reduces glinting and flickering of details on ships and other models when they are far away. The MSAA settings is already shown in SCPUI as a separate dropdown list so this PR adds it as an option to KNet.

Also, this PR sets the default values for shadows to disabled and AA preset to SMAA Low, which is what FSO sets as defaults.