### PR TITLE
Add Deferred Option to Graphic Settings and Cleanup MSAA

### DIFF
--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -401,9 +401,10 @@ namespace Knossos.NET.Models
                     aaPreset = int.Parse(data["Graphics"]["AAMode"]);
                 }
 
-                if (!string.IsNullOrEmpty(data["Graphics"]["MSAAMode"]))
+                if (!string.IsNullOrEmpty(data["Graphics"]["MSAASamples"]))
                 {
-                    msaaPreset = int.Parse(data["Graphics"]["MSAAMode"]);
+                    // recall MSAASamples is in intervals of 4 (0, 4, 8) so convert to preset level
+                    msaaPreset = int.Parse(data["Graphics"]["MSAASamples"]) / 4;
                 }
 
                 if (!string.IsNullOrEmpty(data["Graphics"]["SoftParticles"]))
@@ -628,7 +629,7 @@ namespace Knossos.NET.Models
                 }
                 data["Graphics"]["Shadows"] = shadowQuality.ToString();
                 data["Graphics"]["AAMode"] = aaPreset.ToString();
-                data["Graphics"]["MSAAMode"] = msaaPreset.ToString();
+                data["Graphics"]["MSAASamples"] = (msaaPreset * 4).ToString(); // recall MSAASamples is in intervals of 4 (0, 4, 8) so convert to preset level
                 data["Graphics"]["WindowMode"] = windowMode.ToString();
                 data["Graphics"]["Display"] = displayIndex.ToString();
                 data["Graphics"]["TextureFilter"] = textureFilter.ToString();

--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -82,6 +82,8 @@ namespace Knossos.NET.Models
         [JsonIgnore]
         public bool enableSoftParticles { get; set; } = true;
         [JsonIgnore]
+        public bool enableDeferredLighting { get; set; } = true;
+        [JsonIgnore]
         public int windowMode { get; set; } = 2;
         [JsonIgnore]
         public bool vsync { get; set; } = true;
@@ -409,6 +411,11 @@ namespace Knossos.NET.Models
                     enableSoftParticles = bool.Parse(data["Graphics"]["SoftParticles"]);
                 }
 
+                if (!string.IsNullOrEmpty(data["Graphics"]["DeferredLighting"]))
+                {
+                    enableDeferredLighting = bool.Parse(data["Graphics"]["DeferredLighting"]);
+                }
+
                 if (!string.IsNullOrEmpty(data["Graphics"]["VSync"]))
                 {
                     vsync = bool.Parse(data["Graphics"]["VSync"]);
@@ -626,6 +633,7 @@ namespace Knossos.NET.Models
                 data["Graphics"]["Display"] = displayIndex.ToString();
                 data["Graphics"]["TextureFilter"] = textureFilter.ToString();
                 data["Graphics"]["SoftParticles"] = enableSoftParticles.ToString().ToLower();
+                data["Graphics"]["DeferredLighting"] = enableDeferredLighting.ToString().ToLower();
                 data["Graphics"]["VSync"] = vsync.ToString().ToLower();
                 data["Graphics"]["PostProcessing"] = postProcess.ToString().ToLower();
 
@@ -763,11 +771,15 @@ namespace Knossos.NET.Models
                     case 2: cmd += "-msaa 8"; break;
                 }
             }
-                if (enableSoftParticles)
+            if (enableSoftParticles)
             {
                 cmd += "-soft_particles";
             }
-            switch(windowMode)
+            if (!enableDeferredLighting)
+            {
+                cmd += "-no_deferred";
+            }
+            switch (windowMode)
             {
                 case 0: cmd += "-window"; break;
                 case 1: cmd += "-fullscreen_window"; break;

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -93,6 +93,8 @@ namespace Knossos.NET.ViewModels
         [ObservableProperty]
         private bool enableSoftParticles = true;
         [ObservableProperty]
+        private bool enableDeferredLighting = true;
+        [ObservableProperty]
         private int windowMode = 2;
         [ObservableProperty]
         private bool vsync = true;
@@ -311,6 +313,8 @@ namespace Knossos.NET.ViewModels
             MsaaSelectedIndex = Knossos.globalSettings.msaaPreset;
             //SoftParticles
             EnableSoftParticles = Knossos.globalSettings.enableSoftParticles;
+            //DeferredLighting
+            EnableDeferredLighting = Knossos.globalSettings.enableDeferredLighting;
             //WindowMode
             WindowMode = Knossos.globalSettings.windowMode;
             //VSYNC
@@ -812,6 +816,8 @@ namespace Knossos.NET.ViewModels
             Knossos.globalSettings.msaaPreset = MsaaSelectedIndex;
             //SoftParticles
             Knossos.globalSettings.enableSoftParticles = EnableSoftParticles;
+            //DeferredLighting
+            Knossos.globalSettings.enableDeferredLighting = EnableDeferredLighting;
             //WindowMode
             Knossos.globalSettings.windowMode = WindowMode;
             //VSYNC

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -190,17 +190,21 @@
                 <ComboBoxItem Tag="8">Ultra</ComboBoxItem>
               </ComboBox>
             </Grid>
-						<!-- Enable soft particles -->
+						<!-- Enable deferred lighting -->
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<CheckBox Tag="-soft_particles" Grid.Column="0" IsChecked="{Binding EnableSoftParticles}" Width="200">Enable soft particles</CheckBox>
+							<CheckBox Tag="-no_deferred" Grid.Column="0" IsChecked="{Binding EnableDeferredLighting}" Width="200">Enable Deferred Lighting</CheckBox>
 						</Grid>
+            <!-- Enable soft particles -->
+            <Grid ColumnDefinitions="Auto,Auto" Margin="5">
+              <CheckBox Tag="-soft_particles" Grid.Column="0" IsChecked="{Binding EnableSoftParticles}" Width="200">Enable Soft Particles</CheckBox>
+            </Grid>
 						<!-- VSYNC -->
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<CheckBox Tag="-no_vsync" Grid.Column="0" IsChecked="{Binding Vsync}" Width="200">VSync</CheckBox>
+							<CheckBox Tag="-no_vsync" Grid.Column="0" IsChecked="{Binding Vsync}" Width="200">Enable VSync</CheckBox>
 						</Grid>
 						<!-- Disable Post Processing -->
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<CheckBox Tag="-no_post_process" Grid.Column="0" IsChecked="{Binding PostProcess}" Width="200">Post Processing</CheckBox>
+							<CheckBox Tag="-no_post_process" Grid.Column="0" IsChecked="{Binding PostProcess}" Width="200">Enable Post Processing</CheckBox>
 						</Grid>
 						<!-- FPS Cap -->
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -184,7 +184,7 @@
             <!-- SMAA Filter -->
             <Grid ColumnDefinitions="Auto,Auto" Margin="5">
               <Label Grid.Column="0" Width="200" VerticalAlignment="Center">Extra Multisample Anti-Aliasing</Label>
-              <ComboBox  ToolTip.Tip="High performance impact, especially at Ultra" Tag="-msaa" SelectedIndex="{Binding MsaaSelectedIndex}" Grid.Column="1" IsEnabled="{Binding EnableMSAA}" Width="150" Margin="10,0,0,0">
+              <ComboBox  ToolTip.Tip="High performance impact, especially at Ultra or at >= 4k resolution" Tag="-msaa" SelectedIndex="{Binding MsaaSelectedIndex}" Grid.Column="1" IsEnabled="{Binding EnableMSAA}" Width="150" Margin="10,0,0,0">
                 <ComboBoxItem Tag="0">Disabled</ComboBoxItem>
                 <ComboBoxItem Tag="4">High</ComboBoxItem>
                 <ComboBoxItem Tag="8">Ultra</ComboBoxItem>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -27,7 +27,7 @@
 				<!--KNOSSOS SETTINGS-->
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
-						<Label FontWeight="Bold">Knossos Settings</Label>
+						<Label FontWeight="Bold" FontSize="18">Knossos Settings</Label>
 						<!-- Base Path -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="185">Library Path</TextBlock>
@@ -128,7 +128,7 @@
 				<!--VIDEO SETTINGS-->
 				<Border BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
-						<Label FontWeight="Bold">Video Settings</Label>
+						<Label FontWeight="Bold" FontSize="18">Video Settings</Label>
 						<!-- Resolution -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Display Resolution</TextBlock>
@@ -184,7 +184,7 @@
             <!-- SMAA Filter -->
             <Grid ColumnDefinitions="Auto,Auto" Margin="5">
               <Label Grid.Column="0" Width="200" VerticalAlignment="Center">Extra Multisample Anti-Aliasing</Label>
-              <ComboBox  ToolTip.Tip="High performance impact, especially at Ultra or at >= 4k resolution" Tag="-msaa" SelectedIndex="{Binding MsaaSelectedIndex}" Grid.Column="1" IsEnabled="{Binding EnableMSAA}" Width="150" Margin="10,0,0,0">
+              <ComboBox ToolTip.Tip="High performance impact, especially at Ultra or at >= 4k resolution" Tag="-msaa" SelectedIndex="{Binding MsaaSelectedIndex}" Grid.Column="1" IsEnabled="{Binding EnableMSAA}" Width="150" Margin="10,0,0,0">
                 <ComboBoxItem Tag="0">Disabled</ComboBoxItem>
                 <ComboBoxItem Tag="4">High</ComboBoxItem>
                 <ComboBoxItem Tag="8">Ultra</ComboBoxItem>
@@ -220,7 +220,7 @@
 				<!--Audio SETTINGS-->
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
-						<Label FontWeight="Bold">Audio Settings</Label>
+						<Label FontWeight="Bold" FontSize="18">Audio Settings</Label>
 						<!-- Playback -->
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Playback Devices</TextBlock>
@@ -285,7 +285,7 @@
 				<!--INPUT SETTINGS-->
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
-						<Label FontWeight="Bold">Input Settings</Label>
+						<Label FontWeight="Bold" FontSize="18">Input Settings</Label>
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Mouse Sensitivity</TextBlock>
 							<Slider Grid.Column="1" Width="500" Value="{Binding MouseSensitivity}" Maximum="9" Minimum="0"></Slider>
@@ -328,7 +328,7 @@
 				<!--MOD SETTINGS-->
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
-						<Label FontWeight="Bold">FSO Global Settings</Label>
+						<Label FontWeight="Bold" FontSize="18">FSO Global Settings</Label>
 						<!-- GLOBAL CMDLINE -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<Label ToolTip.Tip="This cmdline will be added to all mods and will override any mod settings using the same flags." Grid.Column="0" VerticalContentAlignment="Center" Width="210">Global Cmdline</Label>


### PR DESCRIPTION
Adds deferred lighting as an option in the graphics settings, since turning this off really helps with performance on low end machines. Also made the capitalization more consistent with graphic user displayed text. At the moment I have `Enable` as a prefix to the checkbox text, but perhaps it would be cleaner to leave that out? (IE `Enable Soft Particles` vs `Soft Particles`)