### PR TITLE
set application name

### DIFF
--- a/Knossos.NET/App.axaml
+++ b/Knossos.NET/App.axaml
@@ -3,6 +3,10 @@
              xmlns:local="using:Knossos.NET"
 			 RequestedThemeVariant="Dark"
              x:Class="Knossos.NET.App">
+    <Application.Name>
+        Knossos.NET
+    </Application.Name>
+
     <Application.DataTemplates>
         <local:ViewLocator/>
     </Application.DataTemplates>


### PR DESCRIPTION
Set the application name properly to avoid macOS and some Linux DEs from just seeing it as "Avalonia Application".