### PR TITLE
Switch QtFRED and Details mini-tab positions

### DIFF
--- a/Knossos.NET/Views/Templates/ModCardView.axaml
+++ b/Knossos.NET/Views/Templates/ModCardView.axaml
@@ -32,7 +32,7 @@
 			<StackPanel IsVisible="{Binding !IsInstalling}" Name="Overlay" ZIndex="1" Background="Black" Height="225" Width="151" VerticalAlignment="Top">
 				<Label Content="{Binding ModVersion}" FontWeight="Bold" FontSize="14" Width="151" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Foreground="White"/>
 				<!--Installed Overlay-->
-				<TabControl IsVisible="{Binding IsInstalled}" Margin="0,-15,0,0">
+				<TabControl IsVisible="{Binding IsInstalled}" Margin="0,-12,0,0">
 					<TabItem>
 						<TabItem.Header>
 							<Label FontWeight="Bold" FontSize="13" Foreground="White">Main</Label>
@@ -44,7 +44,7 @@
 							<Button Command="{Binding ButtonCommand}" CommandParameter="settings" Content="Settings" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" CornerRadius="40" HorizontalContentAlignment="Center" HorizontalAlignment="Center" Background="Crimson" Margin="0,2,0,0" Width="100" ></Button>
 						</StackPanel>
 					</TabItem>
-					<TabItem Margin="-5" IsVisible="{Binding !IsLocalMod}">
+					<TabItem Margin="-5, 0, 0 0" IsVisible="{Binding !IsLocalMod}">
 						<TabItem.Header>
 							<Label FontWeight="Bold" FontSize="13" Foreground="White">Advanced</Label>
 						</TabItem.Header>

--- a/Knossos.NET/Views/Templates/ModCardView.axaml
+++ b/Knossos.NET/Views/Templates/ModCardView.axaml
@@ -40,7 +40,7 @@
 						<StackPanel Margin="5">
 							<Button Command="{Binding ButtonCommand}" CommandParameter="play" Content="Play" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" CornerRadius="40" HorizontalContentAlignment="Center" HorizontalAlignment="Center" Background="Green" Margin="0,2,0,0" Width="100" ></Button>
 							<Button Command="{Binding ButtonCommand}" CommandParameter="fred2" Content="Fred2" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" CornerRadius="40" HorizontalContentAlignment="Center" HorizontalAlignment="Center" Background="DarkOrange" Margin="0,2,0,0" Width="100" ></Button>
-							<Button Command="{Binding ButtonCommand}" CommandParameter="qtfred" Content="QtFred" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" CornerRadius="40" HorizontalContentAlignment="Center" HorizontalAlignment="Center" Background="Purple" Margin="0,2,0,0" Width="100" ></Button>
+							<Button Command="{Binding ButtonCommand}" CommandParameter="details" Content="Details" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" CornerRadius="40" HorizontalContentAlignment="Center" HorizontalAlignment="Center" Background="DarkGray" Margin="0,2,0,0" Width="100" ></Button>
 							<Button Command="{Binding ButtonCommand}" CommandParameter="settings" Content="Settings" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" CornerRadius="40" HorizontalContentAlignment="Center" HorizontalAlignment="Center" Background="Crimson" Margin="0,2,0,0" Width="100" ></Button>
 						</StackPanel>
 					</TabItem>
@@ -50,9 +50,9 @@
 						</TabItem.Header>
 						<StackPanel Margin="5">
 							<Button Command="{Binding ButtonCommand}" CommandParameter="debug" Content="FSO Debug" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" CornerRadius="40" HorizontalContentAlignment="Center" HorizontalAlignment="Center" Background="Orange" Margin="0,2,0,0" Width="100" ></Button>
+							<Button Command="{Binding ButtonCommand}" CommandParameter="qtfred" Content="QtFred" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" CornerRadius="40" HorizontalContentAlignment="Center" HorizontalAlignment="Center" Background="Purple" Margin="0,2,0,0" Width="100" ></Button>
 							<Button Command="{Binding ButtonCommand}" CommandParameter="update" Content="Update/Modify" IsVisible="{Binding UpdateAvalible}" FontWeight="Bold" FontSize="11" VerticalContentAlignment="Center" CornerRadius="40" HorizontalContentAlignment="Center" HorizontalAlignment="Center" Background="Blue" Margin="0,2,0,0" Width="100" ></Button>
 							<Button Command="{Binding ButtonCommand}" CommandParameter="modify" Content="Modify" IsVisible="{Binding !UpdateAvalible}" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" CornerRadius="40" HorizontalContentAlignment="Center" HorizontalAlignment="Center" Background="DarkCyan" Margin="0,2,0,0" Width="100" ></Button>
-							<Button Command="{Binding ButtonCommand}" CommandParameter="details" Content="Details" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" CornerRadius="40" HorizontalContentAlignment="Center" HorizontalAlignment="Center" Background="DarkGray" Margin="0,2,0,0" Width="100" ></Button>
 							<Button Command="{Binding ButtonCommand}" CommandParameter="delete" Content="Delete" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" CornerRadius="40" HorizontalContentAlignment="Center" HorizontalAlignment="Center" Background="Red" Margin="0,2,0,0" Width="100" ></Button>
 						</StackPanel>
 					</TabItem>


### PR DESCRIPTION
I know Fred and QTFred are next to each other in old Knossos, but since QTFred does not fully work it would be more useful for it to the Advanced min-tab and put Details in its place. (If QTFred ever does get done it can replace actual FRED). This change would especially help new folks who don't know what QTFred is, as they won't realize it does not fully work yet.

Happy to edit this PR further as needed, too.