### PR TITLE
fix builds from release workflow

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,5 +1,7 @@
 name: Create Release
 
+# NOTE: this file is only intended to be used when triggered by a version tag!
+
 on:
   push:
     tags:
@@ -9,12 +11,57 @@ permissions:
   contents: write
 
 env:
-  OUTPUT_DIR: ${{ github.workspace }}/build/packages
-  PUBLISH_DIR: ${{ github.workspace }}/build/publish
+  OUTPUT_DIR: ./build/packages
+  PUBLISH_DIR: ./build/publish
 
 jobs:
-  build:
-    name: Build and Release
+  publish:
+    name: Publish builds
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: '${{ github.ref }}'
+
+      - name: Set environment
+        shell: bash
+        run: |
+          echo "VERSION=$(echo ${{ github.ref_name }} | cut -c 2-)" >> $GITHUB_ENV
+          echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: Create directories
+        shell: bash
+        run: |
+          mkdir -p "$OUTPUT_DIR"
+          mkdir -p "$PUBLISH_DIR"
+
+      - name: Publish all RIDs
+        shell: bash
+        run: ./ci/publish_all.sh
+
+      - name: Archive builds
+        shell: bash
+        run: |
+          cd "$PUBLISH_DIR"
+          tar -czvf builds.tgz --exclude='*.pdb' *
+
+      - name: Upload build archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: builds
+          path: ${{ env.PUBLISH_DIR }}/builds.tgz
+          retention-days: 5
+
+  package_release:
+    name: Package and release
+    needs: publish
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -22,6 +69,12 @@ jobs:
         with:
           fetch-depth: 0
           ref: '${{ github.ref }}'
+
+      - name: Set environment
+        shell: bash
+        run: |
+          echo "VERSION=$(echo ${{ github.ref_name }} | cut -c 2-)" >> $GITHUB_ENV
+          echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
 
       - name: Install utilities
         # zip for packaging windows builds
@@ -32,8 +85,16 @@ jobs:
           mkdir -p "$OUTPUT_DIR"
           mkdir -p "$PUBLISH_DIR"
 
-      - name: Publish all RIDs
-        run: ${{ github.workspace }}/ci/publish_all.sh
+      - name: Download build archive
+        uses: actions/download-artifact@v3
+        with:
+          name: builds
+          path: ${{ env.PUBLISH_DIR }}
+
+      - name: Extract build archive
+        run: |
+          cd "$PUBLISH_DIR"
+          tar -xzvf builds.tgz
 
       - name: Package all RIDs
         run: ${{ github.workspace }}/ci/package_all.sh

--- a/ci/bundle_appimage.sh
+++ b/ci/bundle_appimage.sh
@@ -49,7 +49,8 @@ esac
 [ -f "$OUTPUT_DIR/Linux_$DOTNET_ARCH.tar.gz" ] || fail_msg "ERROR: Linux $DOTNET_ARCH archive not found!"
 
 
-VERSION="$(grep string\ AppVersion -rI $NAME | cut -d \" -f 2)" # this will surely come back to bite me
+# VERSION="$(grep string\ AppVersion -rI $NAME | cut -d \" -f 2)" # this will surely come back to bite me
+VERSION="${VERSION:="0.0.0"}"
 
 BUILD_DIR="/appimage"
 APPDIR="$BUILD_DIR/AppDir"
@@ -132,7 +133,7 @@ export APPIMAGE_EXTRACT_AND_RUN=1
 # arm64 appimagetool doesn't run properly in qemu multiarch so work around it
 [ "$DOTNET_ARCH" = "arm64" ] && LAUNCHER="qemu-aarch64-static" || LAUNCHER=""
 
-$LAUNCHER "$BUILD_DIR/appimagetool" -u "$UPDATE_SCHEME" "$APPDIR" "$OUTPUT_DIR/$NAME-$VERSION-$ARCH.AppImage"
+$LAUNCHER "$BUILD_DIR/appimagetool" -u "$UPDATE_SCHEME" "$APPDIR" "$OUTPUT_DIR/$NAME-$ARCH.AppImage"
 
 # zsync file is saved to current directory so move it to proper place
-[ -f "$NAME-$VERSION-$ARCH.AppImage.zsync" ] && mv "$NAME-$VERSION-$ARCH.AppImage.zsync" "$OUTPUT_DIR"
+[ -f "$NAME-$ARCH.AppImage.zsync" ] && mv "$NAME-$ARCH.AppImage.zsync" "$OUTPUT_DIR"

--- a/ci/package_all.sh
+++ b/ci/package_all.sh
@@ -46,6 +46,7 @@ for rid in $RIDS; do
     if [ ${rid:0:3} = "win" ]; then
         zip "$OUTPUT_DIR/$fname.zip" * -x \*.pdb
     else
+        chmod +x "$NAME"  # make sure binary is executable
         tar -czvf "$OUTPUT_DIR/$fname.tar.gz" --exclude='*.pdb' *
     fi
 


### PR DESCRIPTION
Windows builds don't work properly when built on non-Windows platforms so do all of the builds on a Windows runner and then switch to Linux for the rest of the packaging and release actions.

Handle version better by pulling it from git tag. Also remove version from AppImage filenames to ease auto-update system.